### PR TITLE
added menu entry for the package settings

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,39 @@
+[
+    {
+        "caption": "Preferences",
+        "mnemonic": "n",
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "id": "ScopeHunter",
+                        "caption": "ScopeHunter",
+                        "children":
+                        [
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/ScopeHunter/scope_hunter.sublime-settings"
+                                },
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file", "args":
+                                {
+                                    "file": "${packages}/User/scope_hunter.sublime-settings"
+                                },
+                                "caption": "Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,9 @@ Show scope under cursor or cursors (depending whether multi-select is enabled)
 ## Scope Hunter: Toggle Instant Scoper
 Toggle scoping under cursor constantly.
 
+## Scope Hunter: User Settings
+In order to change the standard settings of Scope Hunter, please go to `Preferences -> Package Settings -> Scope Hunter` and click on `Settings - User`.  Repeat that for `Settings - Default`, copy all the settings from the default file to the user settings file, which you would like to change.
+
 # Features
 All features are configurable via the settings file
 


### PR DESCRIPTION
Hello Isaac,

I took the liberty to add menu entries for Scope Hunter to the `Preferences -> Package Settings` menu for the default and user settings.  Also I added a paragraph with instructions about the settings to the readme.md file.

I tested it at my Mac OS X system and it worked so far.

Thank you & take care,
Mick
