### PR TITLE
New setting: multiline scope

### DIFF
--- a/scope_hunter.py
+++ b/scope_hunter.py
@@ -74,7 +74,10 @@ class GetSelectionScope(object):
             self.status = scope
             self.first = False
 
-        self.scope_bfr.append("%-25s %s" % ("Scope:", self.view.scope_name(pt)))
+        if self.multiline_scope:
+            self.scope_bfr.append("Scope:\n    " + self.view.scope_name(pt).strip().replace(" ", "\n    "))
+        else:
+            self.scope_bfr.append("%-25s %s" % ("Scope:", self.view.scope_name(pt)))
 
         if not initialized:
             init_color_scheme()
@@ -120,6 +123,7 @@ class GetSelectionScope(object):
         self.highlight_style = sh_settings.get("highlight_style", 'underline')
         self.highlight_max_size = int(sh_settings.get("highlight_max_size", 100))
         self.show_selectors = bool(sh_settings.get("show_color_scheme_info", False))
+        self.multiline_scope = bool(sh_settings.get("multiline_scope", False))
         self.first = True
         self.extents = []
 

--- a/scope_hunter.sublime-settings
+++ b/scope_hunter.sublime-settings
@@ -33,5 +33,9 @@
     "show_color_scheme_info": false,
 
     // Max region to size to highlight
-    "highlight_max_size": 100
+    "highlight_max_size": 100,
+
+    // Split scope onto multiple lines in
+    // panel and console (easier to read)
+    "multiline_scope": false
 }


### PR DESCRIPTION
Many thanks for creating this great plugin Isaac :)

I had an idea for an improvement. Displaying the whole scope on one line can be rather difficult to read:

```
Scope: source.python meta.function-call.python meta.function-call.arguments.python meta.item-access.python meta.item-access.arguments.python constant.numeric.integer.decimal.python
```

So I've implemented a "multiline scope" setting, which causes the scope to be split onto multiple lines to make it easier to read:

```
Scope:
    source.python
    meta.function-call.python
    meta.function-call.arguments.python
    meta.item-access.python
    meta.item-access.arguments.python
    constant.numeric.integer.decimal.python
```

I find this really helpful. What do you think?