### PR TITLE
Add support for showing scope context backtrace

### DIFF
--- a/popup.j2
+++ b/popup.j2
@@ -2,6 +2,15 @@
 {{plugin.scope}}
 [(copy)](copy-scope:{{plugin.scope_index}}){: .small}
 
+{% if plugin.context_backtrace %}
+## Scope Context Backtrace {: .header}
+  {% for ctx in plugin.context_backtrace_stack %}
+**{{loop.index}}:**{: .keyword} {{ctx}}
+
+  {% endfor %}
+[(copy)](copy-context-backtrace:{{plugin.context_backtrace_index}}){: .small}
+{% endif %}
+
 {% if plugin.pt_extent or plugin.rowcol_extent %}
 ## Scope Extent {: .header}
   {% if plugin.pt_extent %}

--- a/scope_hunter.sublime-settings
+++ b/scope_hunter.sublime-settings
@@ -31,6 +31,9 @@
     // Additional Scope Info
     ///////////////////////////
 
+    // Show the scope backtrace (ST >= 4087)
+    "context_backtrace": true,
+
     // Show scope extent in point format
     "extent_points": false,
 


### PR DESCRIPTION
I use the `get_selection_scope` from this plugin to override the built-in `show_scope_name` command because `get_selection_scope` provides a superset of `show_scope_name`. As of ST 4087, the built-in `show_scope_name` command also shows a scope context backtrace, which can be useful when developing a syntax definition. 

This PR proposes introducing it into this plugin as well.

![image](https://user-images.githubusercontent.com/6594915/94336496-3b5a8280-0016-11eb-9d8c-59b986e7c445.png)

