### PR TITLE
Refactor scope backtrace to be in the same way with builtin's

### DIFF
--- a/scope_hunter.py
+++ b/scope_hunter.py
@@ -366,15 +366,14 @@ class GetSelectionScope:
         backtraces_html = []
         for i, ctx in enumerate(stack):
             if SCOPE_CONTEXT_BACKTRACE_SUPPORT_v4127:
-                source_file = ctx.source_file + ':' + ':'.join(map(str, ctx.source_location))
-                backtraces_text.append("{}. {} ({})".format(i + 1, ctx.context_name, source_file))
-                backtraces_html.append("{} (<a href='{}'>{}</a>)".format(
+                source_path = display_path = '{}:{}:{}'.format(ctx.source_file, *ctx.source_location)
+                if source_path.startswith('Packages/'):
+                    source_path = '${packages}/' + source_path[9:]
+                backtraces_text.append('{}. {} ({})'.format(i + 1, ctx.context_name, display_path))
+                backtraces_html.append('{} (<a href="{}">{}</a>)'.format(
                     ctx.context_name,
-                    sublime.command_url(
-                        'open_file',
-                        {"file": '${packages}' + source_file[len('Packages'):], "encoded_position": True},
-                    ),
-                    source_file,
+                    sublime.command_url('open_file', {'file': source_path, 'encoded_position': True}),
+                    display_path,
                 ))
             elif SCOPE_CONTEXT_BACKTRACE_SUPPORT_v4087:
                 backtraces_text.append(ctx)


### PR DESCRIPTION
In https://github.com/facelessuser/ScopeHunter/pull/61, it assumes the source file path always starts with `Packages/`. This PR only replace `Packages/` with `${packages}` if it starts with `Packages/`. This is how it's done in `Default/show_scope_name.py`.