### PR TITLE
Fix scope context not working

### DIFF
--- a/scope_hunter.py
+++ b/scope_hunter.py
@@ -370,7 +370,7 @@ class GetSelectionScope:
                 if source_path.startswith('Packages/'):
                     source_path = '${packages}/' + source_path[9:]
                 backtraces_text.append('{}. {} ({})'.format(i + 1, ctx.context_name, display_path))
-                backtraces_html.append('{} (<a href="{}">{}</a>)'.format(
+                backtraces_html.append("{} (<a href='{}'>{}</a>)".format(
                     ctx.context_name,
                     sublime.command_url('open_file', {'file': source_path, 'encoded_position': True}),
                     display_path,

--- a/scope_hunter.py
+++ b/scope_hunter.py
@@ -364,14 +364,16 @@ class GetSelectionScope:
 
         backtraces_text = []
         backtraces_html = []
-        for i, ctx in enumerate(stack):
+        for i, ctx in enumerate(reversed(stack)):
             if SCOPE_CONTEXT_BACKTRACE_SUPPORT_v4127:
-                source_path = display_path = '{}:{}:{}'.format(ctx.source_file, *ctx.source_location)
+                source_path = '{}:{}:{}'.format(ctx.source_file, *ctx.source_location)
+                display_path = '{}:{}:{}'.format(os.path.splitext(ctx.source_file)[0], *ctx.source_location)
                 if source_path.startswith('Packages/'):
                     source_path = '${packages}/' + source_path[9:]
+                    display_path = display_path[9:]
                 backtraces_text.append('{}. {} ({})'.format(i + 1, ctx.context_name, display_path))
                 backtraces_html.append("{} (<a href='{}'>{}</a>)".format(
-                    ctx.context_name,
+                    '<em>%s</em>' % ctx.context_name if ctx.context_name.startswith("anonymous ") else ctx.context_name,
                     sublime.command_url('open_file', {'file': source_path, 'encoded_position': True}),
                     display_path,
                 ))


### PR DESCRIPTION
Fixes https://github.com/facelessuser/ScopeHunter/commit/7d789b2c5b92ff0f5486212c3456863d650020e6#r67624449 and some minor changes for display path like the built-in popup.

- Remove leading `Packages/` and file extension from display paths
- Italic context name for anonymous contexts